### PR TITLE
feat: Header・Footer・BaseLayoutの作成

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,19 @@
+---
+---
+<footer class="bg-gray-800 text-gray-400 text-sm py-6 mt-auto">
+  <div class="max-w-screen-xl mx-auto px-4 text-center space-y-1">
+    <p>PHP8初級試験対策サイト</p>
+    <p>
+      問題は
+      <a
+        href="https://study.prime-strategy.co.jp/#exam-list"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-indigo-400 hover:text-indigo-300 underline transition-colors"
+      >
+        プライム・ストラテジー社の模擬試験
+      </a>
+      の出題傾向を参考に作成しています。
+    </p>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,21 @@
+---
+---
+<header class="fixed top-0 left-0 right-0 z-50 bg-indigo-700 text-white shadow-md">
+  <div class="max-w-screen-xl mx-auto px-4 h-14 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-2 font-bold text-lg tracking-tight hover:text-indigo-200 transition-colors">
+      <span class="text-2xl">🐘</span>
+      <span>PHP8初級試験対策</span>
+    </a>
+    <nav class="flex items-center gap-4 text-sm">
+      <a href="/" class="hover:text-indigo-200 transition-colors">トップ</a>
+      <a
+        href="https://www.php.net/manual/ja/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-indigo-200 transition-colors"
+      >
+        公式マニュアル ↗
+      </a>
+    </nav>
+  </div>
+</header>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,31 @@
+---
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description = 'PHP8技術者認定初級試験の対策サイトです。' } = Astro.props;
+---
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title} | PHP8初級試験対策</title>
+  </head>
+  <body class="bg-gray-50 text-gray-900 min-h-screen flex flex-col">
+    <Header />
+    <main class="flex-1 pt-14">
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- `Header.astro`: 固定ヘッダー（サイトタイトル・公式マニュアルへのリンク）
- `Footer.astro`: プライム・ストラテジー社へのクレジットリンクを含むフッター
- `BaseLayout.astro`: 全ページ共通のHTML骨格（メタタグ・Header・Footer・スロット）

## Test plan

- [ ] devサーバーでHeaderが画面上部に固定表示されることを確認
- [ ] Footerがページ最下部に表示されることを確認
- [ ] モバイル幅でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)