### PR TITLE
feat: 問題と選択肢をランダム表示するシャッフル機能を追加

### DIFF
--- a/src/pages/chapters/[slug]/quiz.astro
+++ b/src/pages/chapters/[slug]/quiz.astro
@@ -125,14 +125,36 @@ const questionsJson = JSON.stringify(chapterQuestions);
     } catch {}
   }
 
-  const questions = JSON.parse(questionsJson);
-  if (questions.length === 0) {
+  const allQuestions = JSON.parse(questionsJson);
+  if (allQuestions.length === 0) {
     // 問題なし → スクリプト不要
   } else {
+    function shuffle(arr) {
+      const a = [...arr];
+      for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+      }
+      return a;
+    }
+
+    function shuffleOptions(q) {
+      const shuffled = shuffle(q.options);
+      const newCorrectId = String.fromCharCode(
+        97 + shuffled.findIndex((o) => o.id === q.correctId)
+      );
+      return {
+        ...q,
+        options: shuffled.map((opt, i) => ({ id: String.fromCharCode(97 + i), text: opt.text })),
+        correctId: newCorrectId,
+      };
+    }
+
+    let questions = [];
     let currentIndex = 0;
     let score = 0;
     let answered = false;
-    const results = [];
+    let results = [];
 
     const questionArea = document.getElementById('question-area');
     const questionCounter = document.getElementById('question-counter');
@@ -145,6 +167,16 @@ const questionsJson = JSON.stringify(chapterQuestions);
     const nextBtn = document.getElementById('next-btn');
     const resultArea = document.getElementById('result-area');
     const retryBtn = document.getElementById('retry-btn');
+
+    function startQuiz() {
+      questions = shuffle(allQuestions).map(shuffleOptions);
+      currentIndex = 0;
+      score = 0;
+      answered = false;
+      results = [];
+      resultArea.classList.add('hidden');
+      showQuestion(0);
+    }
 
     function showQuestion(index) {
       answered = false;
@@ -267,16 +299,9 @@ const questionsJson = JSON.stringify(chapterQuestions);
       });
     }
 
-    retryBtn.addEventListener('click', () => {
-      currentIndex = 0;
-      score = 0;
-      answered = false;
-      results.length = 0;
-      resultArea.classList.add('hidden');
-      showQuestion(0);
-    });
+    retryBtn.addEventListener('click', () => startQuiz());
 
     // 初期表示
-    showQuestion(0);
+    startQuiz();
   }
 </script>

--- a/src/pages/quiz.astro
+++ b/src/pages/quiz.astro
@@ -138,6 +138,18 @@ const questionsJson = JSON.stringify(questions);
     return a;
   }
 
+  function shuffleOptions(q) {
+    const shuffled = shuffle(q.options);
+    const newCorrectId = String.fromCharCode(
+      97 + shuffled.findIndex((o) => o.id === q.correctId)
+    );
+    return {
+      ...q,
+      options: shuffled.map((opt, i) => ({ id: String.fromCharCode(97 + i), text: opt.text })),
+      correctId: newCorrectId,
+    };
+  }
+
   function loadMistakes() {
     try {
       const raw = localStorage.getItem(MISTAKE_KEY);
@@ -183,7 +195,7 @@ const questionsJson = JSON.stringify(questions);
   const resultArea = document.getElementById('result-area');
 
   function startQuiz(pool) {
-    questions = shuffle(pool);
+    questions = shuffle(pool).map(shuffleOptions);
     currentIndex = 0;
     score = 0;
     answered = false;


### PR DESCRIPTION
## Summary

- 全章まとめ・章別クイズの両方で**選択肢の並びをシャッフル**するよう変更
- 章別クイズに**問題順のシャッフル**を追加（これまで固定順だった）
- リトライ時も毎回再シャッフルされるよう章別クイズに `startQuiz()` 関数を導入

## 正誤判定の安全性について

`shuffleOptions` 関数でシャッフル後に `correctId` を新しいラベルへ追跡し直している：

1. 元の選択肢配列をシャッフル
2. シャッフル後の配列で正解オプションが何番目にいるか `findIndex` で確定
3. その位置に新しいラベル（`'a'` / `'b'` / `'c'` / `'d'`）を割り当て → `newCorrectId` を更新
4. `btn.dataset.id` と `onAnswer` の比較はすべて新しいラベルで統一されるためズレなし

## Test plan

- [ ] 章別クイズを開き、問題の出題順が毎回異なることを確認
- [ ] 各問題の選択肢の並びが毎回異なることを確認
- [ ] 正解ボタンを押したとき緑ハイライトされることを確認（正誤判定が正しいこと）
- [ ] 不正解ボタンを押したとき赤ハイライト、正解が緑ハイライトされることを確認
- [ ] リトライ時に再シャッフルされることを確認
- [ ] 全章まとめでも同様に選択肢シャッフルを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)