### PR TITLE
feat: 全問題でエディターボタンを表示

### DIFF
--- a/src/pages/chapters/[slug]/quiz.astro
+++ b/src/pages/chapters/[slug]/quiz.astro
@@ -347,8 +347,8 @@ const questionsJson = JSON.stringify(chapterQuestions);
       nextBtn.textContent =
         currentIndex < questions.length - 1 ? '次の問題 →' : '結果を見る';
 
-      const phpCode = extractPhpCode(q.text);
-      if (phpCode && window.innerWidth >= 768) {
+      if (window.innerWidth >= 768) {
+        const phpCode = extractPhpCode(q.text) ?? '<?php\n';
         const btn = document.createElement('button');
         btn.className = 'flex items-center gap-2 text-sm font-medium text-indigo-600 border border-indigo-300 bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-200 px-4 py-2 rounded-lg transition-colors';
         btn.innerHTML = '<span>⌨</span><span>エディターで確認</span>';


### PR DESCRIPTION
## Summary

- PHPコードを含まない問題でもエディターボタンを表示するよう変更
- コードなし問題では `<?php\n` テンプレートでエディターを開く

## 変更箇所

`onAnswer` 内の条件を `if (phpCode && ...)` → `if (window.innerWidth >= 768)` に変更し、`extractPhpCode` の結果が `null` の場合は `<?php\n` をデフォルトとして使用。

## Test plan

- [x] PHPコードを含む問題で解答後にエディターボタンが表示され、コードが自動入力されることを確認
- [x] PHPコードを含まない問題で解答後にもエディターボタンが表示されることを確認
- [x] コードなし問題でエディターを開くと `<?php` テンプレートが入力されていることを確認
- [x] モバイル幅（768px未満）ではボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)