### PR TITLE
fix: 全章まとめ練習でも全問題にエディターボタンを表示

### DIFF
--- a/src/pages/quiz.astro
+++ b/src/pages/quiz.astro
@@ -387,8 +387,8 @@ const questionsJson = JSON.stringify(questions);
     nextBtn.classList.remove('hidden');
     nextBtn.textContent = currentIndex < questions.length - 1 ? '次の問題 →' : '結果を見る';
 
-    const phpCode = extractPhpCode(q.text);
-    if (phpCode && window.innerWidth >= 768) {
+    if (window.innerWidth >= 768) {
+      const phpCode = extractPhpCode(q.text) ?? '<?php\n';
       const btn = document.createElement('button');
       btn.className = 'flex items-center gap-2 text-sm font-medium text-indigo-600 border border-indigo-300 bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-200 px-4 py-2 rounded-lg transition-colors';
       btn.innerHTML = '<span>⌨</span><span>エディターで確認</span>';


### PR DESCRIPTION
章別クイズと同様に、PHPコードがない問題でも
エディターボタンを表示するよう修正。